### PR TITLE
cmake: make library discoverable via find_package()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,14 @@ name: CI
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
+# Single quotes around ${{runner.workspace}} prevent bash from treating the '\'
+# path separators as escapes. This is required for a job that is run on windows
+# with bash shell.
+
 jobs:
 
   test:
@@ -16,64 +24,66 @@ jobs:
       BUILD_TYPE: ${{ matrix.build-type }}
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: 📁 Create build folder
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      - name: 📚 Install necessary packages
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update
+          sudo apt install -y cmake
 
-    - name: ⚙ Configure
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: 📁 Create build folder
+        run: |
+          cmake -E make_directory '${{runner.workspace}}/build'
 
-    - name: 🛠 Build
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: |
-        cmake --build . --config $BUILD_TYPE -j 2
+      - name: ⚙ Configure
+        working-directory: '${{runner.workspace}}/build'
+        run: |
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DTRACE_BUILD_TESTING=ON
 
-    - name: 🧪 Test
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: ./test_trace
+      - name: 🛠 Build
+        working-directory: '${{runner.workspace}}/build'
+        run: |
+          cmake --build . --config $BUILD_TYPE -j 2
+
+      - name: 🧪 Test
+        working-directory: '${{runner.workspace}}/build'
+        run: ./test_trace
 
   coverage:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: 📚 Install necessary packages
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install numpy coverage 'coveralls<3' wheel
-        sudo apt update
-        sudo apt install lcov
+      - name: 📚 Install necessary packages
+        run: |
+          sudo apt update
+          sudo apt install -y cmake python3-pip lcov
+          python -m pip install --upgrade pip
+          python -m pip install numpy coverage 'coveralls<3' wheel
 
-    - name: 📁 Create build folder
-      run: cmake -E make_directory ${{runner.workspace}}/build
+      - name: 📁 Create build folder
+        run: cmake -E make_directory ${{runner.workspace}}/build
 
-    - name: ⚙ Configure
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DTRACE_TEST_COVERAGE=ON
+      - name: ⚙ Configure
+        working-directory: ${{runner.workspace}}/build
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug -DTRACE_BUILD_TESTING=ON -DTRACE_TEST_COVERAGE=ON
 
-    - name: 🛠 Build
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: |
-        cmake --build . --config Debug -j 2
+      - name: 🛠 Build
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake --build . --config Debug -j 2
 
-    - name: 🧪 Coverage test
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: |
-        lcov -c -i --no-external --directory . --base-directory $GITHUB_WORKSPACE -o baseline.info
-        ./test_trace
-        lcov -c --no-external --directory . --base-directory $GITHUB_WORKSPACE -o after_test.info
-        lcov -a baseline.info -a after_test.info -o total_test.info
-        lcov -r total_test.info \*/tests/\* -o coverage.info
-    - name: upload C++ coverage
-      uses: codecov/codecov-action@v1
-      with:
-        files: ${{runner.workspace}}/build/coverage.info
+      - name: 🧪 Coverage test
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          lcov -c -i --no-external --directory . --base-directory $GITHUB_WORKSPACE -o baseline.info
+          ./test_trace
+          lcov -c --no-external --directory . --base-directory $GITHUB_WORKSPACE -o after_test.info
+          lcov -a baseline.info -a after_test.info -o total_test.info
+          lcov -r total_test.info \*/tests/\* -o coverage.info
+      - name: upload C++ coverage
+        uses: codecov/codecov-action@v1
+        with:
+          files: ${{runner.workspace}}/build/coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.10)
 
 
 ######### Options #########################################
+option( TRACE_BUILD_TESTING "Build trace tests"                     OFF )
 option( TRACE_TEST_COVERAGE "Build trace tests with coverage flags" OFF )
 ###########################################################
 
@@ -101,7 +102,7 @@ install( EXPORT      ${PROJECT_NAME}Targets
 file( WRITE "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in" [[
 @PACKAGE_INIT@
 
-include ( "${CMAKE_CURRENT_LIST_DIR}/TraceTargets.cmake" )
+include( "${CMAKE_CURRENT_LIST_DIR}/TraceTargets.cmake" )
 ]] )
 
 include( CMakePackageConfigHelpers )
@@ -113,7 +114,7 @@ configure_package_config_file(
     NO_SET_AND_CHECK_MACRO
     NO_CHECK_REQUIRED_COMPONENTS_MACRO )
 
-write_basic_package_version_file (
+write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
   VERSION       "${${PROJECT_NAME}_VERSION}"
   COMPATIBILITY AnyNewerVersion
@@ -129,11 +130,8 @@ export( EXPORT ${PROJECT_NAME}Targets
 
 
 ######### Tests ###########################################
-option( BUILD_TESTING ON )
-if ( BUILD_TESTING )
+if( TRACE_BUILD_TESTING )
     enable_testing()
-
-    set( TEST_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR} )
 
     set( TEST_SOURCES
         tests/main.cpp
@@ -146,16 +144,15 @@ if ( BUILD_TESTING )
 
     # Properties
     set_target_properties( test_trace PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY ${TEST_RUNTIME_OUTPUT_DIRECTORY}
-        CXX_STANDARD          17
-        CXX_STANDARD_REQUIRED ON
-        CXX_EXTENSIONS        OFF
-        COMPILE_FLAGS         "${TRACE_COMPILE_FLAGS} ${TRACE_FLAGS_COVERAGE}"
-        LINK_FLAGS            "${TRACE_LINK_FLAGS}    ${TRACE_FLAGS_COVERAGE}" )
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        CXX_STANDARD             17
+        CXX_STANDARD_REQUIRED    ON
+        CXX_EXTENSIONS           OFF
+        COMPILE_FLAGS            "${TRACE_COMPILE_FLAGS} ${TRACE_FLAGS_COVERAGE}"
+        LINK_FLAGS               "${TRACE_LINK_FLAGS}    ${TRACE_FLAGS_COVERAGE}" )
 
     # Add the test
     add_test( NAME              test_trace
-              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
               COMMAND           test_trace --use-colour=yes )
 endif()
 ###########################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,13 +9,12 @@ option( TRACE_TEST_COVERAGE "Build trace tests with coverage flags" OFF )
 
 
 ######### Project Name ####################################
-project( trace )
+project( Trace LANGUAGES CXX VERSION 0.1 )
 set( LIBRARY_NAME trace )
 ###########################################################
 
 
 ######### Info ############################################
-message( STATUS ">> CMAKE_C_COMPILER:     ${CMAKE_C_COMPILER}"   )
 message( STATUS ">> CMAKE_CXX_COMPILER:   ${CMAKE_CXX_COMPILER}" )
 ###########################################################
 
@@ -63,51 +62,102 @@ set( TRACE_SOURCE_FILES
 
 add_library( ${LIBRARY_NAME} ${TRACE_SOURCE_FILES} )
 
+include( GNUInstallDirs )
+
 set_target_properties( ${LIBRARY_NAME} PROPERTIES
     CXX_STANDARD          17
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS        OFF
     COMPILE_FLAGS         "${TRACE_COMPILE_FLAGS} ${TRACE_FLAGS_COVERAGE}"
-    LINK_FLAGS            "${TRACE_LINK_FLAGS}    ${TRACE_FLAGS_COVERAGE}" )
+    LINK_FLAGS            "${TRACE_LINK_FLAGS}    ${TRACE_FLAGS_COVERAGE}"
+    VERSION               "${${PROJECT_NAME}_VERSION}"
+    PUBLIC_HEADER         "${TRACE_HEADER_FILES}" )
 
-target_include_directories( ${LIBRARY_NAME} PUBLIC  ${PROJECT_SOURCE_DIR}/include)
-# target_include_directories( ${LIBRARY_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/thirdparty)
+target_include_directories( ${LIBRARY_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                                                   "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>" )
 
 target_compile_options( ${LIBRARY_NAME} PRIVATE
                         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
                             -Werror -Wall -Wextra -Wpedantic -pedantic-errors -Wconversion -Wsign-conversion >
                         $<$<CXX_COMPILER_ID:MSVC>:
                             /WX /W4 > )
+
+######### installation ####################################
+
+install( TARGETS       ${LIBRARY_NAME}
+         EXPORT        ${PROJECT_NAME}Targets
+         LIBRARY       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT shared_lib
+         ARCHIVE       DESTINATION "${CMAKE_INSTALL_LIBDIR}"                            COMPONENT static_lib
+         RUNTIME       DESTINATION "${CMAKE_INSTALL_BINDIR}"                            COMPONENT executable
+         PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${LIBRARY_NAME}"        COMPONENT headers)
+
+set( ${PROJECT_NAME}_CMAKE_FILES_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${LIBRARY_NAME}" )
+
+install( EXPORT      ${PROJECT_NAME}Targets
+         NAMESPACE   ${PROJECT_NAME}::
+         FILE        ${PROJECT_NAME}Targets.cmake
+         DESTINATION "${${PROJECT_NAME}_CMAKE_FILES_DESTINATION}" )
+
+file( WRITE "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in" [[
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/TraceTargets.cmake" )
+]] )
+
+include( CMakePackageConfigHelpers )
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/Config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${${PROJECT_NAME}_CMAKE_FILES_DESTINATION}"
+    NO_SET_AND_CHECK_MACRO
+    NO_CHECK_REQUIRED_COMPONENTS_MACRO )
+
+write_basic_package_version_file (
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION       "${${PROJECT_NAME}_VERSION}"
+  COMPATIBILITY AnyNewerVersion
+)
+
+install( FILES       "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+         DESTINATION "${${PROJECT_NAME}_CMAKE_FILES_DESTINATION}" )
+
+export( EXPORT ${PROJECT_NAME}Targets
+        FILE   "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake" )
 ###########################################################
 
 
 ######### Tests ###########################################
-enable_testing()
+option( BUILD_TESTING ON )
+if ( BUILD_TESTING )
+    enable_testing()
 
-set( TEST_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR} )
+    set( TEST_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR} )
 
-set( TEST_SOURCES
-    tests/main.cpp
-    tests/should_not_throw.cpp
-    tests/should_throw.cpp )
+    set( TEST_SOURCES
+        tests/main.cpp
+        tests/should_not_throw.cpp
+        tests/should_throw.cpp )
 
-# Executable
-add_executable( test_trace ${TEST_SOURCES} )
-target_link_libraries( test_trace ${LIBRARY_NAME} )
+    # Executable
+    add_executable( test_trace ${TEST_SOURCES} )
+    target_link_libraries( test_trace ${LIBRARY_NAME} )
 
-# Properties
-set_target_properties( test_trace PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${TEST_RUNTIME_OUTPUT_DIRECTORY}
-    CXX_STANDARD          17
-    CXX_STANDARD_REQUIRED ON
-    CXX_EXTENSIONS        OFF
-    COMPILE_FLAGS         "${TRACE_COMPILE_FLAGS} ${TRACE_FLAGS_COVERAGE}"
-    LINK_FLAGS            "${TRACE_LINK_FLAGS}    ${TRACE_FLAGS_COVERAGE}" )
+    # Properties
+    set_target_properties( test_trace PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${TEST_RUNTIME_OUTPUT_DIRECTORY}
+        CXX_STANDARD          17
+        CXX_STANDARD_REQUIRED ON
+        CXX_EXTENSIONS        OFF
+        COMPILE_FLAGS         "${TRACE_COMPILE_FLAGS} ${TRACE_FLAGS_COVERAGE}"
+        LINK_FLAGS            "${TRACE_LINK_FLAGS}    ${TRACE_FLAGS_COVERAGE}" )
 
-# Add the test
-add_test( NAME              test_trace
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-          COMMAND           test_trace --use-colour=yes )
+    # Add the test
+    add_test( NAME              test_trace
+              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+              COMMAND           test_trace --use-colour=yes )
+endif()
 ###########################################################
 
 


### PR DESCRIPTION
Library can be discovered through find_package(CONFIG) mode. Library
produces Trace::trace IMPORTED target to be linked against. The target
is discoverable both in installed state, and when the project is
included as subdirectory.

Additionally, a few minor cleanups are made:
- no need to look for C compiler, there are no C files
- no need to print information about C compiler (no need to print
  information about C++ compiler either, since this is done by CMake
  automatically, but since it exists already, it is probably for a
  reason)
- library version is specified (required for target versioning)
- enable_testing() is wrapped inside BUILD_TESTING, which is a standard
  CMake variable, and set to ON by default to preserve existing behavior

After installation (tested) or inclusion as subdirectory (not tested),
expected usage is:

    find_package(Trace CONFIG REQUIRED)
    target_link_libraries(foobar PRIVATE Trace::trace)

Library can be included via:

    #include <trace/trace.hpp>