### PR TITLE
Remove semicolons from the macro definitions

### DIFF
--- a/include/trace/trace.hpp
+++ b/include/trace/trace.hpp
@@ -2,13 +2,13 @@
 
 // Initiation point for a backtrace
 // This is as deep as the trace will go
-#define initiate( message ) inner::throw_exception( message, __FILE__, __LINE__ );
+#define initiate( message ) inner::throw_exception( message, __FILE__, __LINE__ )
 
 // Propagation point for a backtrace
 // The trace will include information on the function in which this is placed
-#define propagate( message ) inner::rethrow_exception( message, __FILE__, __LINE__ );
+#define propagate( message ) inner::rethrow_exception( message, __FILE__, __LINE__ )
 
 // End point for a backtrace
 // This is where the trace info is accumulated and saved,
 // it can then be extracted with trace::latest_message
-#define handle( ex ) inner::handle_exception( ex, __func__ );
+#define handle( ex ) inner::handle_exception( ex, __func__ )


### PR DESCRIPTION
Firstly, not putting semicolons at the end of a statement looks
unnatural for a C/C++ programmer. Secondly, macros look like normal
functions, therefore they should behave like normal functions, that is,
require a semicolon at the end. Thirdly, when the programmer puts a
semicolon at the end, there is a linter warning about empty statement.